### PR TITLE
Implement layout spec cache

### DIFF
--- a/AsyncDisplayKit/ASLayoutSpec+Debug.m
+++ b/AsyncDisplayKit/ASLayoutSpec+Debug.m
@@ -22,6 +22,7 @@
     self.layoutSpec = layoutSpec;
     self.layoutSpec.neverShouldVisualize = YES;
     self.usesImplicitHierarchyManagement = YES;
+    self.shouldCacheLayoutSpec = YES;
     [self addTarget:self action:@selector(visualizerNodeTapped:) forControlEvents:ASControlNodeEventTouchUpInside];
   }
   return self;

--- a/AsyncDisplayKit/AsyncDisplayKit+Debug.h
+++ b/AsyncDisplayKit/AsyncDisplayKit+Debug.h
@@ -16,6 +16,10 @@
 
 @interface ASDisplayNode (Debugging)
 @property (nonatomic, assign) BOOL shouldVisualizeLayoutSpecs;
+@property (nonatomic, assign) BOOL shouldCacheLayoutSpec;
+
+- (void)clearCachedLayoutSpec;
+
 @end
 
 @interface ASImageNode (Debugging)

--- a/examples/ASLayoutSpecPlayground/Podfile
+++ b/examples/ASLayoutSpecPlayground/Podfile
@@ -1,4 +1,6 @@
 source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '7.1'
-target ‘Sample’
+target 'Sample' do
 	pod 'AsyncDisplayKit', :path => '../..'
+end
+

--- a/examples/ASLayoutSpecPlayground/Sample/PlaygroundContainerNode.m
+++ b/examples/ASLayoutSpecPlayground/Sample/PlaygroundContainerNode.m
@@ -41,6 +41,7 @@
     [ASLayoutableInspectorNode sharedInstance].vizNodeInsetSize = 10.0;
     
     self.shouldVisualizeLayoutSpecs = YES;
+    self.shouldCacheLayoutSpec = YES;
   }
   
   return self;

--- a/examples/ASLayoutSpecPlayground/Sample/PlaygroundNode.m
+++ b/examples/ASLayoutSpecPlayground/Sample/PlaygroundNode.m
@@ -36,6 +36,8 @@
     
     self.backgroundColor                 = [UIColor whiteColor];
     self.usesImplicitHierarchyManagement = YES;
+    self.shouldVisualizeLayoutSpecs = YES;
+    self.shouldCacheLayoutSpec = YES;
     
     _userAvatarImageView     = [[ASNetworkImageNode alloc] init];
     _userAvatarImageView.URL = [NSURL URLWithString:@"https://s-media-cache-ak0.pinimg.com/avatars/503h_1458880322_140.jpg"];
@@ -129,12 +131,11 @@
   
   // vertical stack
   
-  CGFloat cellWidth                  = constrainedSize.max.width;
-  _photoImageView.preferredFrameSize = CGSizeMake(cellWidth, cellWidth);              // constrain photo frame size
+  ASRatioLayoutSpec *photoRatioSpec = [ASRatioLayoutSpec ratioLayoutSpecWithRatio:1.0 child:_photoImageView];
   
   ASStackLayoutSpec *verticalStack   = [ASStackLayoutSpec verticalStackLayoutSpec];
   verticalStack.alignItems           = ASStackLayoutAlignItemsStretch;                // sretch headerStack to fill horizontal space
-  [verticalStack setChildren:@[headerWithInset, _photoImageView, footerWithInset]];
+  [verticalStack setChildren:@[headerWithInset, photoRatioSpec, footerWithInset]];
   verticalStack.flexShrink           = YES;
   
   return verticalStack;


### PR DESCRIPTION
Cache layout specs to ensure layout properties that are manually set by users via the playground UI are reserved across relayouts. We need new UI elements that inform users that a cached spec is being used and provide a way to force the construction of a new spec when needed.

Also, I imagine this will be a helpful off-by-default feature in many production apps. It can be used to avoid constructing the same layout spec tree multiple times. However, there are a few cases in which the cached spec needs to be invalidated:
1. A node has different specs for different constrained sizes. To support this, we can provide a way for nodes to indicate whether a cached spec is still valid or not given the old and new constrained sizes.
2. Some custom internal layout flags are changed. This can be handled by 2 ways:
   1. Users will have to call `clearCachedLayoutSpec` then `setNeedsLayout`.
   2. If `clearCachedLayoutSpec` is automatically called in `__setNeedsLayout`, users will not need to do anything. I tend to believe this option is better.

@hannahmbanana, @appleguy: Really interested in your thoughts here.
